### PR TITLE
node-api-maps_tyk-jgd

### DIFF
--- a/api/swagger/maps.yaml
+++ b/api/swagger/maps.yaml
@@ -46,6 +46,100 @@ paths:
           required: true
           description: 方位の角度
     parameters: []
+  /api/maps/tky2jgdg:
+    get:
+      summary: ''
+      tags:
+        - maps
+      responses:
+        '200':
+          description: ''
+          headers: {}
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: boolean
+                    description: 処理結果
+                  lat:
+                    type: number
+                    description: 十進緯度（世界測地系）
+                  lon:
+                    type: number
+                    description: 十進経度（世界測地系）
+              examples:
+                example:
+                  value:
+                    status: true
+                    lat: 35.68078249
+                    lon: 139.767235
+      operationId: get-api-maps-tky2jgdg
+      description: 日本測地系を世界測地系に変換（1次式）
+      parameters:
+        - schema:
+            type: number
+            format: double
+          in: query
+          name: lat
+          required: true
+          description: 十進緯度（日本測地系）
+        - schema:
+            type: number
+            format: double
+          in: query
+          name: lon
+          required: true
+          description: 十進経度（日本測地系）
+    parameters: []
+  /api/maps/jgd2tkyg:
+    get:
+      summary: ''
+      tags:
+        - maps
+      responses:
+        '200':
+          description: ''
+          headers: {}
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: boolean
+                    description: 処理結果
+                  lat:
+                    type: number
+                    description: 十進緯度（日本測地系）
+                  lon:
+                    type: number
+                    description: 十進経度（日本測地系）
+              examples:
+                example:
+                  value:
+                    status: true
+                    lat: 35.67755556
+                    lon: 139.7704444
+      operationId: get-api-maps-jgd2tkyg
+      description: 世界測地系を日本測地系に変換（1次式）
+      parameters:
+        - schema:
+            type: number
+            format: double
+          in: query
+          name: lat
+          required: true
+          description: 十進緯度（世界測地系）
+        - schema:
+            type: number
+            format: double
+          in: query
+          name: lon
+          required: true
+          description: 十進経度（世界測地系）
+    parameters: []
 tags:
   - name: maps
     description: ''

--- a/src/node/index.ts
+++ b/src/node/index.ts
@@ -2,7 +2,7 @@ import express from 'express';
 import swaggerUi from 'swagger-ui-express'
 import yamljs from 'yamljs'
 
-import { maps } from '../ts/maps';
+import { maps, mapsLatLon } from '../ts/maps';
 
 const app:express.Express = express();
 
@@ -40,21 +40,82 @@ const swaggerDocument = yamljs.load('./api/swagger/maps.yaml');
 app.use('/api/maps/docs', swaggerUi.serve, swaggerUi.setup(swaggerDocument))
 
 // API - maps
+interface mapsData_deg2name {
+	status: boolean
+	, name: string
+};
 router.get('/api/maps/deg2name',
 	(req:express.Request, res:express.Response) => {
+		let data: mapsData_deg2name = {
+			status: false
+			, name: ""
+		};
+		
 		const oMaps: maps = new maps();
 		
-		let name: string = "";
 		if (req.query.deg) {
 			const deg: number = +req.query.deg
 			if (!Number.isNaN(deg)) {
-				name = oMaps.deg2Name(deg);
+				data.status = true;
+				data.name = oMaps.deg2Name(deg);
 			}
 		}
 		
-		const data: {} = {
-			status : true
-			, name : name
+		res.json(data);
+		res.end();
+	}
+);
+
+interface mapsData_LatLon {
+	status: boolean
+	, lat: number
+	, lon: number
+};
+router.get('/api/maps/tky2jgdg',
+	(req:express.Request, res:express.Response) => {
+		let data: mapsData_LatLon = {
+			status: false
+			, lat: 0
+			, lon: 0
+		};
+		
+		const oMaps: maps = new maps();	
+		
+		if (req.query.lat && req.query.lon) {
+			const lat: number = +req.query.lat;
+			const lon: number = +req.query.lon;
+			if (!Number.isNaN(lat) && !Number.isNaN(lon)) {
+				const pos: mapsLatLon = oMaps.tky2jgdG(lat, lon);
+				data.status = true;
+				data.lat = pos.lat;
+				data.lon = pos.lon;
+			}
+		}
+		
+		res.json(data);
+		res.end();
+	}
+);
+
+router.get('/api/maps/jgd2tkyg',
+	(req:express.Request, res:express.Response) => {
+		let data: mapsData_LatLon = {
+			status: false
+			, lat: 0
+			, lon: 0
+		};
+
+		const oMaps: maps = new maps();
+		
+		if (req.query.lat && req.query.lon) {
+			const lat: number = +req.query.lat;
+			const lon: number = +req.query.lon;
+			if (!Number.isNaN(lat) && !Number.isNaN(lon)) {
+				const pos: mapsLatLon = oMaps.jgd2tkyG(lat, lon);
+				data.status = true;
+				data.lat = pos.lat;
+				data.lon = pos.lon;
+			}
 		}
 		
 		res.json(data);


### PR DESCRIPTION
- tky2jgdg：日本測地系を世界測地系に変換（1次式）する API を追加
- jgd2tykg：世界測地系を日本測地系に変換（1次式）する API を追加