### PR TITLE
api-maps-distance-to

### DIFF
--- a/api/swagger/maps.yaml
+++ b/api/swagger/maps.yaml
@@ -328,6 +328,71 @@ paths:
           required: true
           description: 十進経度（世界測地系[GSR80]）
     parameters: []
+  /api/maps/distanceto:
+    get:
+      summary: '角度・距離から緯度経度を取得'
+      tags:
+        - maps
+      responses:
+        '200':
+          description: ''
+          headers: {}
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: boolean
+                    description: 処理結果
+                  lat:
+                    type: number
+                    description: 十進緯度（世界測地系[GSR80]）
+                  lon:
+                    type: number
+                    description: 十進経度（世界測地系[GSR80]）
+              examples:
+                example:
+                  value:
+                    status: true
+                    lat: 43.06473675180286
+                    lon: 141.3469832298937
+      operationId: get-api-maps-distanceto
+      description: 角度・距離から緯度経度を取得
+      parameters:
+        - schema:
+            type: number
+            format: double
+            default: 35.689753
+          in: query
+          name: lat
+          required: true
+          description: 十進緯度（世界測地系[GSR80]）
+        - schema:
+            type: number
+            format: double
+            default: 139.691731
+          in: query
+          name: lon
+          required: true
+          description: 十進経度（世界測地系[GSR80]）
+        - schema:
+            type: number
+            format: double
+            default: 9.362103972638495
+          in: query
+          name: a
+          required: true
+          description: 角度
+        - schema:
+            type: number
+            format: double
+            default: 831070.2256498174
+          in: query
+          name: len
+          required: true
+          description: 距離（m）
+    parameters: []
 tags:
   - name: maps
     description: ''

--- a/api/swagger/maps.yaml
+++ b/api/swagger/maps.yaml
@@ -393,6 +393,67 @@ paths:
           required: true
           description: 距離（m）
     parameters: []
+  /api/maps/direction:
+    get:
+      summary: '２地点間の角度'
+      tags:
+        - maps
+      responses:
+        '200':
+          description: ''
+          headers: {}
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: boolean
+                    description: 処理結果
+                  a:
+                    type: number
+                    description: 角度
+              examples:
+                example:
+                  value:
+                    status: true
+                    a: 9.362103972638495
+      operationId: get-api-maps-direction
+      description: ２地点間の角度
+      parameters:
+        - schema:
+            type: number
+            format: double
+            default: 35.689753
+          in: query
+          name: lat1
+          required: true
+          description: 十進緯度（世界測地系[GSR80]）
+        - schema:
+            type: number
+            format: double
+            default: 139.691731
+          in: query
+          name: lon1
+          required: true
+          description: 十進経度（世界測地系[GSR80]）
+        - schema:
+            type: number
+            format: double
+            default: 43.064301
+          in: query
+          name: lat2
+          required: true
+          description: 十進緯度（世界測地系[GSR80]）
+        - schema:
+            type: number
+            format: double
+            default: 141.346874
+          in: query
+          name: lon2
+          required: true
+          description: 十進経度（世界測地系[GSR80]）
+    parameters: []
 tags:
   - name: maps
     description: ''

--- a/src/node/apiMapsDistance.ts
+++ b/src/node/apiMapsDistance.ts
@@ -6,6 +6,11 @@ interface apiMapsDistanceData {
 	, distance: number
 };
 
+interface apiMapsDirectionData {
+	status: boolean
+	, a: number
+};
+
 interface apiMapsDistanceToData {
 	status: boolean
 	, lat: number
@@ -97,6 +102,35 @@ export class apiMapsDistance {
 	}
 
 	/**
+	 * ２地点間の角度
+	 * @param req リクエスト
+	 * @returns 結果
+	 */
+	private direction(req:express.Request): apiMapsDirectionData{
+		let data: apiMapsDirectionData = {
+			status: false
+			, a: 0
+		};
+
+		const oMaps: maps = new maps();
+
+		if (req.query.lat1 && req.query.lon1 && req.query.lat2 && req.query.lon2) {
+			const lat1: number = +req.query.lat1;
+			const lon1: number = +req.query.lon1;
+			const lat2: number = +req.query.lat2;
+			const lon2: number = +req.query.lon2;
+			if (!Number.isNaN(lat1) && !Number.isNaN(lon1) && !Number.isNaN(lat2) && !Number.isNaN(lon2)) {
+				const a: number  = oMaps.direction(lat1, lon1, lat2, lon2);
+				data.status = true;
+				data.a = a;
+			}
+		}
+
+		return data;
+	}
+
+
+	/**
 	 * 登録
 	 * @param router express - Router
 	 */
@@ -152,6 +186,20 @@ export class apiMapsDistance {
 					, lon: 0
 				};
 				data = this.distanceTo(req);
+
+				res.json(data);
+				res.end();
+			}
+		);
+
+		// ２地点間の角度
+		router.get(this.uri + '/direction',
+			(req:express.Request, res:express.Response) => {
+				let data: apiMapsDirectionData = {
+					status: false
+					, a: 0
+				};
+				data = this.direction(req);
 
 				res.json(data);
 				res.end();


### PR DESCRIPTION
- distanceto：角度・距離から地点（緯度経度）を取得する API を追加
- direction：２地点間の角度を取得する API を追加
- maps.yaml の緯度経度のサンプル値は、東京の県庁所在地～北海道の県庁所在地を設定