### PR TITLE
pages-mongo

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -22,7 +22,7 @@ if [ "${TYPE}" = "ver" ]; then
 # build for dev
 elif [ "${TYPE}" = "dev" ]; then
 	build
-        npm run tsc_build_w
+	npm run gulp watch
 # build for release
 else
 	build

--- a/src/ts/appMaps.ts
+++ b/src/ts/appMaps.ts
@@ -79,13 +79,6 @@ export class appMaps {
 			this.oMapApp.style.height = this.options.h + this.options.hUnit;
 		}
 
-		L.tileLayer(
-			"https://cyberjapandata.gsi.go.jp/xyz/std/{z}/{x}/{y}.png"
-			, {
-				attribution: "<a href='https://maps.gsi.go.jp/development/ichiran.html' target='_blank'>GSI</a>"
-			}
-		).addTo(this.oMap);
-
 		this.view(this.lat, this.lon, this.z);
 	}
 
@@ -158,6 +151,21 @@ export class appMaps {
 		if (options.popup) {
 			o.bindPopup(options.popup);
 		}
+	}
+
+	/**
+	 * レイヤー：ベース（地理院地図）
+	 */
+	public layerBase(): void{
+		if (!this.oMap) {
+			return;
+		}
+		L.tileLayer(
+			"https://cyberjapandata.gsi.go.jp/xyz/std/{z}/{x}/{y}.png"
+			, {
+				attribution: "<a href='https://maps.gsi.go.jp/development/ichiran.html' target='_blank'>GSI</a>"
+			}
+		).addTo(this.oMap);
 	}
 
 	/**

--- a/src/ts/appMaps.ts
+++ b/src/ts/appMaps.ts
@@ -79,6 +79,9 @@ export class appMaps {
 			this.oMapApp.style.height = this.options.h + this.options.hUnit;
 		}
 
+		// スケール
+		L.control.scale({imperial: false}).addTo(this.oMap);
+
 		this.view(this.lat, this.lon, this.z);
 	}
 
@@ -194,7 +197,7 @@ export class appMaps {
 
 		const z: number = this.oMap.getZoom();
 		// 都道府県界
-		if (z < 12) {
+		if (z < 10) {
 			this.dPrefCity.remove(this.oMap);
 			this.dPref.set(this.oMap);
 		}

--- a/src/ts/appMapsGeoJSON.ts
+++ b/src/ts/appMapsGeoJSON.ts
@@ -1,3 +1,4 @@
+import {Feature, Geometry} from "geojson";
 import L from "leaflet";
 
 export class appMapsGeoJSON {
@@ -62,7 +63,84 @@ export class appMapsGeoJSON {
 				if (!data) {
 					return;
 				}
-				this.layer = L.geoJSON(data, {});
+				const options: L.GeoJSONOptions = {
+					style: {
+						color: "#000000"
+						, weight: 1
+						, opacity: 0.80
+					}
+					, onEachFeature: (feature: Feature<Geometry, any>, layer: any) => {
+						let pref: number = 0;
+						let name: string = "";
+
+						// pref & prefCitry
+						if (feature.properties) {
+							if (feature.properties.pref) {
+								pref = feature.properties.pref;
+								name = feature.properties.name;
+							}
+							else if (feature.properties.JCODE) {
+								pref = +feature.properties.JCODE.substring(0, 2);
+								const name_gun = feature.properties.GUN ? feature.properties.GUN : "";
+								const name_shikuchoson = feature.properties.SIKUCHOSON ? feature.properties.SIKUCHOSON : "";
+								name = feature.properties.KEN + name_gun + name_shikuchoson;
+							}
+
+							let color: string = "";
+							// 北海道
+							if (pref === 1) {
+								color = "#68cbc6";
+							}
+							// 東北
+							else if (pref >= 2 && pref <= 7) {
+								color = "#81d6eb";
+							}
+							// 関東
+							else if (pref >= 8 && pref <= 14) {
+								color = "#7595ec";
+							}
+							// 北陸
+							else if (pref >= 15 && pref <= 18) {
+								color = "#af6ec2";
+							}
+							// 中部
+							else if (pref >= 19 && pref <= 23) {
+								color = "#da6ea2";
+							}
+							// 近畿
+							else if (pref >= 24 && pref <= 30) {
+								color = "#eea849";
+							}
+							// 中国
+							else if (pref >= 31 && pref <= 35) {
+								color = "#e7d31a";
+							}
+							// 四国
+							else if (pref >= 36 && pref <= 39) {
+								color = "#aed44b";
+							}
+							// 九州
+							else if (pref >= 40 && pref <= 46) {
+								color = "#6eb318";
+							}
+							// 沖縄
+							else if (pref === 47) {
+								color = "#2e9f5f";
+							}
+
+							if (color) {
+								layer.setStyle(
+									{ color: color }
+								);
+							}
+							if (name) {
+								layer.bindPopup(name);
+							}
+						}
+					}
+				}
+
+				this.layer = L.geoJSON(data, options);
 				this.layer.addTo(oMap);
 				this.layerVisible = true;
 			});

--- a/src/ts/appMapsGeoJSON.ts
+++ b/src/ts/appMapsGeoJSON.ts
@@ -1,0 +1,82 @@
+import L from "leaflet";
+
+export class appMapsGeoJSON {
+	private url: string = "";
+	private layer: L.GeoJSON | null = null;
+	private layerVisible: boolean = false;
+
+	/**
+	 * コンストラクター
+	 * @param url geojson
+	 */
+	constructor(url: string) {
+		this.url = url;
+	}
+
+	/**
+	 * 取得
+	 * @param url geojson
+	 * @returns Promise<void>
+	 */
+	private get(url: string): Promise<void> {
+		return new Promise<void>((resolve: (data: any) => void, reject: (reson: any) => void) => {
+			fetch(url,
+				{
+					method: "GET"
+				}
+			).then(res => {
+				if (res.status === 200) {
+					res.text().then(text => {
+						if (text.length > 0) {
+							resolve(JSON.parse(text));
+						}
+						else{
+							resolve({});
+						}
+					}
+					);
+				}
+				else {
+					resolve({});
+				}
+			}
+			).catch(error => {
+				resolve({});
+			}
+			);
+		}
+		);
+	}
+
+	/**
+	 * 設定
+	 * @param oMap leaflet
+	 */
+	public set(oMap: L.Map): void {
+		if (this.layer) {
+			this.layer.addTo(oMap);
+			this.layerVisible = true;
+		}
+		else {
+			this.get(this.url).then((data: any) => {
+				if (!data) {
+					return;
+				}
+				this.layer = L.geoJSON(data, {});
+				this.layer.addTo(oMap);
+				this.layerVisible = true;
+			});
+		}
+	}
+
+	/**
+	 * 削除
+	 * @param pMap leaflet
+	 */
+	public remove(oMap: L.Map): void {
+		if (this.layer && this.layerVisible) {
+			oMap.removeLayer(this.layer);
+			this.layerVisible = false;
+		}
+	}
+}

--- a/src/view/index.ts
+++ b/src/view/index.ts
@@ -457,6 +457,7 @@ function page(oView: indexView) : void {
 			oDivTitle.innerHTML = oView.getMenuTitle("MongoDB");
 
 			oAppMaps = new appMaps("appMongoDBMap", _MapLat, _MapLon, _MapZ, _MapOptions);
+			oAppMaps.layerPref();
 		}
 	}
 }

--- a/src/view/index.ts
+++ b/src/view/index.ts
@@ -450,6 +450,15 @@ function page(oView: indexView) : void {
 			);
 		}
 	}
+	/*==============================================================================================*/
+	if (!oView.status("MongoDB", vHashDiv)) {
+		const oDivTitle: HTMLElement | null = document.getElementById("appMongoDBTitle");
+		if (oDivTitle) {
+			oDivTitle.innerHTML = oView.getMenuTitle("MongoDB");
+
+			oAppMaps = new appMaps("appMongoDBMap", _MapLat, _MapLon, _MapZ, _MapOptions);
+		}
+	}
 }
 
 /**
@@ -463,6 +472,7 @@ window.onload = () => {
 		, { key: "Scale", title: "ズームレベルから縮尺を求める" }
 		, { key: "Tile", title: "緯度経度から地図タイルを取得し、タイル左上原点の「緯度、経度」と標高タイル（TXT、PNG）から「標高」を求める" }
 		, { key: "DataGpx", title: "GPS ログデータ（GPX）を読み込み、「時間、経度、緯度、標高」に加え「距離、角度、勾配、速度」を算出して表示" }
+		, { key: "MongoDB", title: "MongoDB（地理空間データ）によるデータ検索" }
 	];
 	title.map((item: indexMenuTitle) => {
 		oView.setMenuTitle(item);

--- a/src/view/index.ts
+++ b/src/view/index.ts
@@ -47,7 +47,7 @@ function page(oView: indexView) : void {
 		const item_base = dmapsDataPrefCapital[base];
 		const oDiv: HTMLElement | null = document.getElementById("appDistance");
 		oAppMaps = new appMaps("appDistanceMap", _MapLat, _MapLon, _MapZ, _MapOptions);
-
+		oAppMaps.layerBase();
 		if (!oDiv || !oAppMaps) {
 			return;
 		}

--- a/src/view/indexViewContents.tsx
+++ b/src/view/indexViewContents.tsx
@@ -35,6 +35,10 @@ export class IndexViewContents extends React.Component {
 				<div id="appDataGpxTitleSub"></div>
 				<div id="appDataGpx"></div>
 			</div>
+			<div id="MongoDB" className="contents">
+				■　<span id="appMongoDBTitle"></span><br />
+				<div id="appMongoDBMap"></div>
+			</div>
 			</>
 		);
 	}


### PR DESCRIPTION
- MongoDB のデータ検索ページ（地図）を作成（ベースのページのみで検索処理は未実装）
- 地図に 都道府県、市区町村界の GeoJSON(ポリゴン) を Leaflet 上にズームレベルに応じて切り替え表示
	- 地域別にポリゴンの色を着色
	- ポリゴンクリック時に都道府県名、市区町村名をポップアップ表示
- 地図にスケールを表示